### PR TITLE
Capitalize plist tab

### DIFF
--- a/manifests/templates/manifests/detail.html
+++ b/manifests/templates/manifests/detail.html
@@ -28,7 +28,7 @@
       <a href="#detailtab" aria-controls="editortab" role="tab" data-toggle="tab">Details</a>
     </li>
     <li role="presentation">
-      <a href="#plisttab" aria-controls="plisttab" role="tab" data-toggle="tab">plist</a>
+      <a href="#plisttab" aria-controls="plisttab" role="tab" data-toggle="tab">Plist</a>
     </li>
   </ul>
   <!-- Tab panes -->

--- a/pkgsinfo/templates/pkgsinfo/detail.html
+++ b/pkgsinfo/templates/pkgsinfo/detail.html
@@ -25,7 +25,7 @@
       <a href="#detailtab" aria-controls="editortab" role="tab" data-toggle="tab">Details</a>
     </li>
     <li role="presentation">
-      <a href="#plisttab" aria-controls="plisttab" role="tab" data-toggle="tab">plist</a>
+      <a href="#plisttab" aria-controls="plisttab" role="tab" data-toggle="tab">Plist</a>
     </li>
   </ul>
   <!-- Tab panes -->


### PR DESCRIPTION
Visually this tab should match the Basics and Details tabs.
