### PR TITLE
Lock plist editor fields to vertical resizing

### DIFF
--- a/manifests/static/manifests/css/manifests.css
+++ b/manifests/static/manifests/css/manifests.css
@@ -45,4 +45,5 @@ tbody.connectable {
     position: relative;
     top: 4px;
     left: -2px;
+    resize: vertical;
 }

--- a/munkiwebadmin/static/css/plisteditor.css
+++ b/munkiwebadmin/static/css/plisteditor.css
@@ -5,8 +5,9 @@
 
 .plist-editor .property,
 .plist-editor .value {
-  border: none;
-  background-color: inherit;
+    border: none;
+    background-color: inherit;
+    resize: vertical;
 }
 
 .plist-editor input[type="checkbox"] {


### PR DESCRIPTION
Fixes issue #16 by disabling horizontal field resizing. Fields can still be vertically resized if needed.