### PR TITLE
Don't capture unused stderr in makecatalogs

### DIFF
--- a/process/views.py
+++ b/process/views.py
@@ -96,7 +96,7 @@ def run(request):
             time.sleep(1)
 
         proc = subprocess.Popen([MAKECATALOGS, REPO_DIR],
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                stdout=subprocess.PIPE)
         record = Process(name='makecatalogs')
         record.pid = proc.pid
         record.save()


### PR DESCRIPTION
stderr is not used and capturing it can cause the process to hang because it is not read from